### PR TITLE
Add grunt-cli dependency to fix builds on Travis

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.0",
+    "grunt-cli": "~0.1",
     "grunt-contrib-jshint": "~0.1.1",
     "grunt-contrib-watch": "~0.2.0",
     "grunt-contrib-nodeunit": "~0.1.2"


### PR DESCRIPTION
I noticed your builds on Travis are failing with `grunt: not found`. I think adding grunt-cli as a dependency will fix that.
